### PR TITLE
Fix bug with date-only formats

### DIFF
--- a/src/main/java/seedu/address/model/event/DateTime.java
+++ b/src/main/java/seedu/address/model/event/DateTime.java
@@ -15,7 +15,8 @@ import java.util.Map;
  */
 public class DateTime {
 
-    public static final String RECOMMENDED_FORMAT = "dd/MM/yyyy HH:mm";
+    public static final String RECOMMENDED_FORMAT = "dd/MM/yyyy";
+    public static final String RECOMMENDED_FORMAT_WITH_TIME = "dd/MM/yyyy HH:mm";
     public static final String MESSAGE_CONSTRAINTS =
             "Dates should follow a valid format. Try " + RECOMMENDED_FORMAT;
 
@@ -51,6 +52,7 @@ public class DateTime {
         }};
 
     public final LocalDateTime dateTime;
+    private final boolean hasTime;
 
     /**
      * Constructs a {@code DateTime}.
@@ -61,6 +63,7 @@ public class DateTime {
         requireNonNull(dateTime);
         checkArgument(isValidDateTime(dateTime), MESSAGE_CONSTRAINTS);
         this.dateTime = parseDateTime(dateTime);
+        this.hasTime = checkDateHasTime(dateTime);
     }
 
     /**
@@ -104,9 +107,15 @@ public class DateTime {
         }
     }
 
+    public static boolean checkDateHasTime(String dateString) {
+        String dateFormat = determineDateFormat(dateString, TIME_VALIDATION_REGEXS);
+        return dateFormat != null;
+    }
+
     @Override
     public String toString() {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(RECOMMENDED_FORMAT);
+        String pattern = this.hasTime ? RECOMMENDED_FORMAT_WITH_TIME : RECOMMENDED_FORMAT;
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
         return dateTime.format(formatter);
     }
 

--- a/src/main/java/seedu/address/model/event/DateTime.java
+++ b/src/main/java/seedu/address/model/event/DateTime.java
@@ -107,6 +107,9 @@ public class DateTime {
         }
     }
 
+    /**
+     * Returns whether a date string contains a time.
+     */
     public static boolean checkDateHasTime(String dateString) {
         String dateFormat = determineDateFormat(dateString, TIME_VALIDATION_REGEXS);
         return dateFormat != null;

--- a/src/test/java/seedu/address/model/event/DateTimeTest.java
+++ b/src/test/java/seedu/address/model/event/DateTimeTest.java
@@ -50,4 +50,21 @@ public class DateTimeTest {
 
     }
 
+    @Test
+    public void checkHasTime() {
+        // hasTime
+        assertTrue(DateTime.checkDateHasTime("24/02/2022 13:43"));
+        assertTrue(DateTime.checkDateHasTime("18 Mar 2021 16:55"));
+        assertTrue(DateTime.checkDateHasTime("2022-02-01 13:53"));
+        assertTrue(DateTime.checkDateHasTime("15 April 2025 11:46"));
+        assertTrue(DateTime.checkDateHasTime("10-10-2010 10:53"));
+
+        // not hasTime
+        assertFalse(DateTime.checkDateHasTime("24/02/2022"));
+        assertFalse(DateTime.checkDateHasTime("18 Mar 2021"));
+        assertFalse(DateTime.checkDateHasTime("2022-02-01"));
+        assertFalse(DateTime.checkDateHasTime("15 April 2025"));
+        assertFalse(DateTime.checkDateHasTime("10-10-2010"));
+    }
+
 }


### PR DESCRIPTION
- Add a variable `hasTime` that is true when the format provided has a time.
- Updated the `toString` method to return the appropriate string based on the above variable.
- Updates the JSON file and UI with the correct string.

Closes #87 