### PR TITLE
Add tag shortcuts functionality

### DIFF
--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -21,8 +21,9 @@ public class Tag {
      */
     public Tag(String tagName) {
         requireNonNull(tagName);
-        checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
-        this.tagName = tagName;
+        String temp = TagUtil.retrieveTagString(tagName);
+        checkArgument(isValidTagName(temp), MESSAGE_CONSTRAINTS);
+        this.tagName = temp;
     }
 
     /**

--- a/src/main/java/seedu/address/model/tag/TagUtil.java
+++ b/src/main/java/seedu/address/model/tag/TagUtil.java
@@ -1,0 +1,32 @@
+package seedu.address.model.tag;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Helper class that contains tag shortcuts.
+ */
+public class TagUtil {
+    private static final Map<String, String> SHORTCUTS = new HashMap<>() {{
+            put("tut", "tutorial");
+            put("assm", "assignment");
+            put("pres", "presentation");
+            put("lec", "lecture");
+        }};
+
+    // to prevent instantiation
+    private TagUtil() {}
+
+    /**
+     * Retrieves the expanded string if shortcut is in variable, else returns the original string
+     */
+    public static String retrieveTagString(String string) {
+        for (String key : SHORTCUTS.keySet()) {
+            if (string.toLowerCase().equals(key)) {
+                return SHORTCUTS.get(key);
+            }
+        }
+        return string;
+    }
+
+}

--- a/src/main/java/seedu/address/model/tag/TagUtil.java
+++ b/src/main/java/seedu/address/model/tag/TagUtil.java
@@ -12,6 +12,9 @@ public class TagUtil {
             put("assm", "assignment");
             put("pres", "presentation");
             put("lec", "lecture");
+            put("prof", "professor");
+            put("ta", "tutor");
+            put("rec", "recitation");
         }};
 
     // to prevent instantiation

--- a/src/test/java/seedu/address/model/tag/TagUtilTest.java
+++ b/src/test/java/seedu/address/model/tag/TagUtilTest.java
@@ -1,0 +1,24 @@
+package seedu.address.model.tag;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class TagUtilTest {
+
+    @Test
+    public void retrieveTagString_shortcutPresent_returnsResultString() {
+        assertEquals(TagUtil.retrieveTagString("assm"), "assignment");
+        assertEquals(TagUtil.retrieveTagString("tut"), "tutorial");
+        assertEquals(TagUtil.retrieveTagString("lec"), "lecture");
+    }
+
+    @Test
+    public void retrieveTagString_shortcutNotPresent_returnsSameString() {
+        String testTagA = "tagA";
+        String testTagB = "tagB";
+        assertEquals(TagUtil.retrieveTagString(testTagA), testTagA);
+        assertEquals(TagUtil.retrieveTagString(testTagB), testTagB);
+    }
+
+}

--- a/src/test/java/seedu/address/model/tag/TagUtilTest.java
+++ b/src/test/java/seedu/address/model/tag/TagUtilTest.java
@@ -11,6 +11,10 @@ public class TagUtilTest {
         assertEquals(TagUtil.retrieveTagString("assm"), "assignment");
         assertEquals(TagUtil.retrieveTagString("tut"), "tutorial");
         assertEquals(TagUtil.retrieveTagString("lec"), "lecture");
+        
+        // case insensitive check
+        assertEquals(TagUtil.retrieveTagString("LEC"), "lecture");
+        assertEquals(TagUtil.retrieveTagString("tuT"), "tutorial");
     }
 
     @Test

--- a/src/test/java/seedu/address/model/tag/TagUtilTest.java
+++ b/src/test/java/seedu/address/model/tag/TagUtilTest.java
@@ -11,7 +11,7 @@ public class TagUtilTest {
         assertEquals(TagUtil.retrieveTagString("assm"), "assignment");
         assertEquals(TagUtil.retrieveTagString("tut"), "tutorial");
         assertEquals(TagUtil.retrieveTagString("lec"), "lecture");
-        
+
         // case insensitive check
         assertEquals(TagUtil.retrieveTagString("LEC"), "lecture");
         assertEquals(TagUtil.retrieveTagString("tuT"), "tutorial");


### PR DESCRIPTION
A small list of tag shortcuts has been implemented:

- `tut` -> `tutorial`
- `lec` -> `lecture`
- `assm` -> `assignment`
- `pres` -> `presentation`

Please feel free to let me know what other shortcuts we can add in the comments! We also need to consider whether we should make this list available to the user somehow.

I've added this feature to orient our platform more towards the target audience.