### PR TITLE
Fix issues with dates

### DIFF
--- a/src/main/java/seedu/address/model/event/DateTime.java
+++ b/src/main/java/seedu/address/model/event/DateTime.java
@@ -45,21 +45,21 @@ public class DateTime implements Comparable<DateTime> {
     public static final HashSet<String> REGEX_DATES = new LinkedHashSet<>() {
         {
             add("((?<dateGroup>" + REGEX_DAY + "-" + REGEX_MONTH + "(-" + REGEX_YEAR + ")?))"
-                    + "(\\s(?<timeGroup>" + REGEX_TIME_COLON + "))?");
+                    + "(\\s+(?<timeGroup>" + REGEX_TIME_COLON + "))?");
             add("((?<dateGroup>" + REGEX_DAY + "-" + REGEX_MONTH + "(-" + REGEX_YEAR + ")?))"
-                    + "(\\s(?<timeGroup>" + REGEX_TIME_NO_SPACE + "))?");
+                    + "(\\s+(?<timeGroup>" + REGEX_TIME_NO_SPACE + "))?");
             add("((?<dateGroup>" + REGEX_YEAR + "-" + REGEX_MONTH + "-" + REGEX_DAY + "))"
-                    + "(\\s(?<timeGroup>" + REGEX_TIME_COLON + "))?");
+                    + "(\\s+(?<timeGroup>" + REGEX_TIME_COLON + "))?");
             add("((?<dateGroup>" + REGEX_YEAR + "-" + REGEX_MONTH + "-" + REGEX_DAY + "))"
-                    + "(\\s(?<timeGroup>" + REGEX_TIME_NO_SPACE + "))?");
+                    + "(\\s+(?<timeGroup>" + REGEX_TIME_NO_SPACE + "))?");
             add("((?<dateGroup>" + REGEX_DAY + "/" + REGEX_MONTH + "(/" + REGEX_YEAR + ")?))"
-                    + "(\\s(?<timeGroup>" + REGEX_TIME_COLON + "))?");
+                    + "(\\s+(?<timeGroup>" + REGEX_TIME_COLON + "))?");
             add("((?<dateGroup>" + REGEX_DAY + "/" + REGEX_MONTH + "(/" + REGEX_YEAR + ")?))"
-                    + "(\\s(?<timeGroup>" + REGEX_TIME_NO_SPACE + "))?");
+                    + "(\\s+(?<timeGroup>" + REGEX_TIME_NO_SPACE + "))?");
             add("((?<dateGroup>" + REGEX_YEAR + "/" + REGEX_MONTH + "/" + REGEX_DAY + "))"
-                    + "(\\s(?<timeGroup>" + REGEX_TIME_COLON + "))?");
+                    + "(\\s+(?<timeGroup>" + REGEX_TIME_COLON + "))?");
             add("((?<dateGroup>" + REGEX_YEAR + "/" + REGEX_MONTH + "/" + REGEX_DAY + "))"
-                    + "(\\s(?<timeGroup>" + REGEX_TIME_NO_SPACE + "))?");
+                    + "(\\s+(?<timeGroup>" + REGEX_TIME_NO_SPACE + "))?");
         }
     };
 

--- a/src/main/java/seedu/address/model/event/DateTime.java
+++ b/src/main/java/seedu/address/model/event/DateTime.java
@@ -34,13 +34,12 @@ public class DateTime implements Comparable<DateTime> {
     public static final String REGEX_YEAR = "(?<yearGroup>\\d{4})";
     public static final String REGEX_MONTH = "(?<monthGroup>" + "(\\d{1,2})" + "|" + "[A-Za-z]{3,}" + ")";
     public static final String REGEX_DAY = "(?<dayGroup>\\d{1,2})";
-    public static final String REGEX_SECONDS = "(?<secondsGroup>\\d{2})";
     public static final String REGEX_MINUTES = "(?<minutesGroup>\\d{2})";
     public static final String REGEX_HOURS = "(?<hoursGroup>\\d{2})";
     public static final String REGEX_TIME_COLON =
-            "(" + REGEX_HOURS + ":" + REGEX_MINUTES + "(:" + REGEX_SECONDS + ")?)";
+            "(" + REGEX_HOURS + ":" + REGEX_MINUTES + ")";
     public static final String REGEX_TIME_NO_SPACE =
-            "(" + REGEX_HOURS + REGEX_MINUTES + "(" + REGEX_SECONDS + ")?)";
+            "(" + REGEX_HOURS + REGEX_MINUTES + ")";
 
     public static final HashSet<String> REGEX_DATES = new LinkedHashSet<>() {
         {
@@ -81,13 +80,9 @@ public class DateTime implements Comparable<DateTime> {
     /**
      * Returns a LocalTime object for an input time in the valid formats.
      */
-    private static LocalTime generateLocalTime(String hours, String minutes,
-                                               String seconds) throws DateTimeParseException {
-        if (seconds == null) {
-            return LocalTime.parse(hours + ":" + minutes, DateTimeFormatter.ofPattern("HH:mm"));
-        }
-        return LocalTime.parse(hours + ":" + minutes + ":" + seconds,
-                DateTimeFormatter.ofPattern("HH:mm:ss"));
+    private static LocalTime generateLocalTime(String hours, String minutes) throws DateTimeParseException {
+        return LocalTime.parse(hours + ":" + minutes,
+                DateTimeFormatter.ofPattern("HH:mm"));
     }
 
     /**
@@ -169,9 +164,8 @@ public class DateTime implements Comparable<DateTime> {
 
         String hours = matcher.group("hoursGroup");
         String minutes = matcher.group("minutesGroup");
-        String seconds = matcher.group("secondsGroup");
 
-        return Optional.ofNullable(generateLocalTime(hours, minutes, seconds));
+        return Optional.ofNullable(generateLocalTime(hours, minutes));
     }
 
     public static String getDifferenceString(DateTime start, DateTime end) {

--- a/src/main/java/seedu/address/model/event/DateTime.java
+++ b/src/main/java/seedu/address/model/event/DateTime.java
@@ -44,14 +44,6 @@ public class DateTime implements Comparable<DateTime> {
 
     public static final HashSet<String> REGEX_DATES = new LinkedHashSet<>() {
         {
-            add("((?<dateGroup>" + REGEX_DAY + "\\s" + REGEX_MONTH + "(\\s" + REGEX_YEAR + ")?))"
-                    + "(\\s(?<timeGroup>" + REGEX_TIME_COLON + "))?");
-            add("((?<dateGroup>" + REGEX_DAY + "\\s" + REGEX_MONTH + "(\\s" + REGEX_YEAR + ")?))"
-                    + "(\\s(?<timeGroup>" + REGEX_TIME_NO_SPACE + "))?");
-            add("((?<dateGroup>" + REGEX_YEAR + "\\s" + REGEX_MONTH + "\\s" + REGEX_DAY + "))"
-                    + "(\\s(?<timeGroup>" + REGEX_TIME_COLON + "))?");
-            add("((?<dateGroup>" + REGEX_YEAR + "\\s" + REGEX_MONTH + "\\s" + REGEX_DAY + "))"
-                    + "(\\s(?<timeGroup>" + REGEX_TIME_NO_SPACE + "))?");
             add("((?<dateGroup>" + REGEX_DAY + "-" + REGEX_MONTH + "(-" + REGEX_YEAR + ")?))"
                     + "(\\s(?<timeGroup>" + REGEX_TIME_COLON + "))?");
             add("((?<dateGroup>" + REGEX_DAY + "-" + REGEX_MONTH + "(-" + REGEX_YEAR + ")?))"

--- a/src/test/java/seedu/address/model/event/DateTimeTest.java
+++ b/src/test/java/seedu/address/model/event/DateTimeTest.java
@@ -102,18 +102,6 @@ public class DateTimeTest {
                 DateTime.parseTime(validDate + "23:59"));
         assertEquals(Optional.ofNullable(LocalTime.parse("00:00")),
                 DateTime.parseTime(validDate + "00:00"));
-
-        // HHmmss
-        assertEquals(Optional.ofNullable(LocalTime.parse("23:59:59")),
-                DateTime.parseTime(validDate + "235959"));
-        assertEquals(Optional.ofNullable(LocalTime.parse("00:00:00")),
-                DateTime.parseTime(validDate + "000000"));
-
-        // HH:mm:ss
-        assertEquals(Optional.ofNullable(LocalTime.parse("23:59:59")),
-                DateTime.parseTime(validDate + "23:59:59"));
-        assertEquals(Optional.ofNullable(LocalTime.parse("00:00:00")),
-                DateTime.parseTime(validDate + "00:00:00"));
     }
 
     @Test
@@ -128,14 +116,6 @@ public class DateTimeTest {
         // 60 as minutes
         assertThrows(DateTimeParseException.class, () -> DateTime.parseTime(validDate + "2360"));
         assertThrows(DateTimeParseException.class, () -> DateTime.parseTime(validDate + "23:60"));
-
-        // 60 as seconds
-        assertThrows(DateTimeParseException.class, () -> DateTime.parseTime(validDate + "235960"));
-        assertThrows(DateTimeParseException.class, () -> DateTime.parseTime(validDate + "23:59:60"));
-
-        // 60 as minutes and 60 as seconds
-        assertThrows(DateTimeParseException.class, () -> DateTime.parseTime(validDate + "236060"));
-        assertThrows(DateTimeParseException.class, () -> DateTime.parseTime(validDate + "23:60:60"));
     }
 
     @Test
@@ -152,9 +132,7 @@ public class DateTimeTest {
 
         // day, month, time only
         assertTrue(DateTime.isValidDateTime("22/22 0000"));
-        assertTrue(DateTime.isValidDateTime("22-22 999999"));
         assertTrue(DateTime.isValidDateTime("22/22 00:00"));
-        assertTrue(DateTime.isValidDateTime("22-22 99:99:99"));
 
         // day, month, year only
         assertTrue(DateTime.isValidDateTime("24/02/2022"));
@@ -166,7 +144,6 @@ public class DateTimeTest {
         // day, month, year, time
         assertTrue(DateTime.isValidDateTime("24/02/2022 26:24"));
         assertTrue(DateTime.isValidDateTime("24/02/2022 99:99"));
-        assertTrue(DateTime.isValidDateTime("24/02/2022 99:99:99"));
         assertTrue(DateTime.isValidDateTime("31/Jan/2015 13:66"));
         assertTrue(DateTime.isValidDateTime("24/02/2022 13:43"));
         assertTrue(DateTime.isValidDateTime("31-Jan-2015 16:21"));
@@ -174,7 +151,7 @@ public class DateTimeTest {
 
         // longer whitespace
         assertTrue(DateTime.isValidDateTime("25-05-2018               04:55"));
-        assertTrue(DateTime.isValidDateTime("25/jun/2018                            04:55"));
+        assertTrue(DateTime.isValidDateTime("25/jun/2018                            0455"));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/event/DateTimeTest.java
+++ b/src/test/java/seedu/address/model/event/DateTimeTest.java
@@ -29,44 +29,39 @@ public class DateTimeTest {
         // different separators dd mm yy
         assertEquals(LocalDate.parse("2022-11-23"), DateTime.parseDate("23/11/2022"));
         assertEquals(LocalDate.parse("2022-11-23"), DateTime.parseDate("23-11-2022"));
-        assertEquals(LocalDate.parse("2022-12-23"), DateTime.parseDate("23 12 2022"));
 
         // different separators yyyy mm dd
         assertEquals(LocalDate.parse("2022-11-23"), DateTime.parseDate("2022/11/23"));
         assertEquals(LocalDate.parse("2022-11-23"), DateTime.parseDate("2022-11-23"));
-        assertEquals(LocalDate.parse("2022-12-23"), DateTime.parseDate("2022 12 23"));
 
         // single day and month
         assertEquals(LocalDate.parse("2000-01-01"), DateTime.parseDate("1/1/2000"));
         assertEquals(LocalDate.parse("2000-01-01"), DateTime.parseDate("1-1-2000"));
-        assertEquals(LocalDate.parse("2000-01-01"), DateTime.parseDate("1 1 2000"));
 
         // single day
         assertEquals(LocalDate.parse("2000-12-01"), DateTime.parseDate("1/12/2000"));
         assertEquals(LocalDate.parse("2000-12-01"), DateTime.parseDate("1-12-2000"));
-        assertEquals(LocalDate.parse("2000-12-01"), DateTime.parseDate("1 12 2000"));
 
         // single month
         assertEquals(LocalDate.parse("2000-01-12"), DateTime.parseDate("12/1/2000"));
         assertEquals(LocalDate.parse("2000-01-12"), DateTime.parseDate("12-1-2000"));
-        assertEquals(LocalDate.parse("2000-01-12"), DateTime.parseDate("12 1 2000"));
 
         // parses february correctly
         assertEquals(LocalDate.parse("2022-02-28"), DateTime.parseDate("28/2/2022"));
         assertEquals(LocalDate.parse("2020-02-29"), DateTime.parseDate("29/2/2020"));
 
         // parses letters correctly
-        assertEquals(LocalDate.parse("2022-10-10"), DateTime.parseDate("10 oct 2022"));
-        assertEquals(LocalDate.parse("2022-07-04"), DateTime.parseDate("4 jUly 2022"));
+        assertEquals(LocalDate.parse("2022-10-10"), DateTime.parseDate("10/oct/2022"));
+        assertEquals(LocalDate.parse("2022-07-04"), DateTime.parseDate("4-jUly-2022"));
 
         // parses dd-mm
         String year = String.valueOf(LocalDate.now().getYear());
-        assertEquals(LocalDate.parse(year + "-10-10"), DateTime.parseDate("10 oCt"));
+        assertEquals(LocalDate.parse(year + "-10-10"), DateTime.parseDate("10-oCt"));
         assertEquals(LocalDate.parse(year + "-07-04"), DateTime.parseDate("4/7"));
 
         // valid years
-        assertEquals(LocalDate.parse("0001-10-01"), DateTime.parseDate("01 october 0001"));
-        assertEquals(LocalDate.parse("9999-10-01"), DateTime.parseDate("01 october 9999"));
+        assertEquals(LocalDate.parse("0001-10-01"), DateTime.parseDate("01/october/0001"));
+        assertEquals(LocalDate.parse("9999-10-01"), DateTime.parseDate("01-october-9999"));
 
     }
 
@@ -76,17 +71,17 @@ public class DateTimeTest {
         assertThrows(DateTimeParseException.class, () -> DateTime.parseDate("99/99/9999"));
 
         // random month
-        assertThrows(DateTimeParseException.class, () -> DateTime.parseDate("20 whatmonth 2022"));
+        assertThrows(DateTimeParseException.class, () -> DateTime.parseDate("20-whatmonth-2022"));
 
         // zeroes
-        assertThrows(DateTimeParseException.class, () -> DateTime.parseDate("00 october 2022"));
-        assertThrows(DateTimeParseException.class, () -> DateTime.parseDate("01 00 2022"));
+        assertThrows(DateTimeParseException.class, () -> DateTime.parseDate("00-october-2022"));
+        assertThrows(DateTimeParseException.class, () -> DateTime.parseDate("01-00-2022"));
 
         // invalid date do not parse
-        assertThrows(DateTimeParseException.class, () -> DateTime.parseDate("31 february 2022"));
-        assertThrows(DateTimeParseException.class, () -> DateTime.parseDate("30 february 2020"));
+        assertThrows(DateTimeParseException.class, () -> DateTime.parseDate("31/february/2022"));
+        assertThrows(DateTimeParseException.class, () -> DateTime.parseDate("30-february-2020"));
 
-        assertThrows(DateTimeParseException.class, () -> DateTime.parseDate("01 october 0000"));
+        assertThrows(DateTimeParseException.class, () -> DateTime.parseDate("01/october/0000"));
     }
 
     @Test
@@ -94,7 +89,7 @@ public class DateTimeTest {
         final String validDate = "23/11/2022 ";
         // no time
         assertEquals(Optional.empty(), DateTime.parseTime("23/11/2022"));
-        assertEquals(Optional.empty(), DateTime.parseTime("1 jan 1998"));
+        assertEquals(Optional.empty(), DateTime.parseTime("1-jan-1998"));
 
         // HHmm
         assertEquals(Optional.ofNullable(LocalTime.parse("23:59")),
@@ -151,10 +146,9 @@ public class DateTimeTest {
         assertTrue(DateTime.isValidDateTime("22/2"));
         assertTrue(DateTime.isValidDateTime("22/22"));
         assertTrue(DateTime.isValidDateTime("22-22"));
-        assertTrue(DateTime.isValidDateTime("22 22"));
-        assertTrue(DateTime.isValidDateTime("22 Oct"));
-        assertTrue(DateTime.isValidDateTime("22 acdef"));
-        assertTrue(DateTime.isValidDateTime("2 octOber"));
+        assertTrue(DateTime.isValidDateTime("22-Oct"));
+        assertTrue(DateTime.isValidDateTime("22/acdef"));
+        assertTrue(DateTime.isValidDateTime("2/octOber"));
 
         // day, month, time only
         assertTrue(DateTime.isValidDateTime("22/22 0000"));
@@ -164,19 +158,23 @@ public class DateTimeTest {
 
         // day, month, year only
         assertTrue(DateTime.isValidDateTime("24/02/2022"));
-        assertTrue(DateTime.isValidDateTime("31 Jan 2015"));
+        assertTrue(DateTime.isValidDateTime("31/Jan/2015"));
         assertTrue(DateTime.isValidDateTime("25-05-2018"));
         assertTrue(DateTime.isValidDateTime("40/02/2022"));
-        assertTrue(DateTime.isValidDateTime("21 Rep 2015"));
+        assertTrue(DateTime.isValidDateTime("21-Rep-2015"));
 
         // day, month, year, time
         assertTrue(DateTime.isValidDateTime("24/02/2022 26:24"));
         assertTrue(DateTime.isValidDateTime("24/02/2022 99:99"));
         assertTrue(DateTime.isValidDateTime("24/02/2022 99:99:99"));
-        assertTrue(DateTime.isValidDateTime("31 Jan 2015 13:66"));
+        assertTrue(DateTime.isValidDateTime("31/Jan/2015 13:66"));
         assertTrue(DateTime.isValidDateTime("24/02/2022 13:43"));
-        assertTrue(DateTime.isValidDateTime("31 Jan 2015 16:21"));
+        assertTrue(DateTime.isValidDateTime("31-Jan-2015 16:21"));
         assertTrue(DateTime.isValidDateTime("25-05-2018 04:55"));
+
+        // longer whitespace
+        assertTrue(DateTime.isValidDateTime("25-05-2018               04:55"));
+        assertTrue(DateTime.isValidDateTime("25/jun/2018                            04:55"));
     }
 
     @Test


### PR DESCRIPTION
- [x] Remove DD MM YYYY, DD MM, YYYY MM DD as valid dates
- [x] Allow multiple white spaces between date and time 
- [x] Remove seconds from time
- [x] Update dates test cases
- [ ] Update user guide (Add YYYY formats into UG, remove the above date and time formats from UG)

**Issues Fixed**
1. Fixes #148, where `dd mm yyyy` was not parsed in the `event -f` command. This is due to how arguments are split by the whitespace, and `dd` `mm` `yyyy` gets split into 3, and cannot be recognised as a date. Although an alternative fix would be to use regex within the `FindEventCommand`, but that would be a really messy thing to do
2. Fixes #152, which has the same issue as above.
3. Fixes #172, where seconds are not displayed in the duration, if we remove seconds entirely in this PR
4. Fixes #175, where multiple white spaces are now allowed